### PR TITLE
Add exception check for KeyboardInterrupt

### DIFF
--- a/PushbuttonLED.py
+++ b/PushbuttonLED.py
@@ -8,17 +8,19 @@ GPIO.setmode(GPIO.BOARD)
 GPIO.setup(12, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 GPIO.setup(16, GPIO.OUT)
 
-while True:
-    inputValue= GPIO.input(12)
-    if (inputValue == False): #Not pressed
-        print("LED is blinking")
-        GPIO.output(16, True) 
-        time.sleep(1)
-        GPIO.output(16, False)
-        time.sleep(1)
-    else: #Pressed
-        GPIO.output(16, True) #LED ON
-        time.sleep(0.03)
-        print("LED is on")
-
-GPIO.cleanup()
+try:
+    while True:
+        inputValue= GPIO.input(12)
+        if (inputValue == False): #Not pressed
+            print("LED is blinking")
+            GPIO.output(16, True) 
+            time.sleep(1)
+            GPIO.output(16, False)
+            time.sleep(1)
+        else: #Pressed
+            GPIO.output(16, True) #LED ON
+            time.sleep(0.03)
+            print("LED is on")
+except KeyboardInterrupt:
+    print("Cleaning up GPIO...")
+    GPIO.cleanup()


### PR DESCRIPTION
I'm still pretty new with Python but I think as written your code never called `GPIO.cleanup()`. It would stay in the `while` loop forever and then when there was a keyboard interrupt in the terminal from the user it would just exit. I've seen other code where it's wrapped in a try - catch block like so and this should cause `GPIO.cleanup()` to be invoked when the program is shut down.